### PR TITLE
👽️ Update QR code page for epubjs library

### DIFF
--- a/add-iscn-qr-code-to-epub/asset/iscn.css
+++ b/add-iscn-qr-code-to-epub/asset/iscn.css
@@ -23,13 +23,17 @@ footer {
   font-size: 0.8em;
 }
 
-#iscn-page-book-info th,
-#iscn-page-book-info td {
+#iscn-page-book-info > div {
+  display: flex;
+}
+
+#iscn-page-book-info > div > b,
+#iscn-page-book-info > div > span {
   padding: 0.25em 2vw;
   vertical-align: top;
 }
 
-#iscn-page-book-info th {
+#iscn-page-book-info > div > span {
   text-align: left;
   white-space: nowrap;
 }

--- a/add-iscn-qr-code-to-epub/asset/iscn.css
+++ b/add-iscn-qr-code-to-epub/asset/iscn.css
@@ -3,51 +3,28 @@ body {
   flex-direction: column;
   height: 100vh;
   font-family: sans-serif;
+  text-align: center;
 }
 
-main {
+#iscn-page-body {
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
   flex-grow: 1;
   padding: 0.5em 2vw 4em;
 }
 
-footer {
+#iscn-page-footer {
   border-top: 1px solid #ccc;
   padding: 0.5em;
 }
 
-#iscn-page-book-info {
-  margin-top: 16px;
-  font-size: 0.8em;
-}
-
-#iscn-page-book-info > div {
-  display: flex;
-}
-
-#iscn-page-book-info > div > b,
-#iscn-page-book-info > div > span {
-  padding: 0.25em 2vw;
-  vertical-align: top;
-}
-
-#iscn-page-book-info > div > span {
-  text-align: left;
-  white-space: nowrap;
-}
-
 #iscn-qr-code {
-  display: block;
   margin-top: 0.5em;
 }
 
 #iscn-prefix {
+  font-size: 0.75em;
   font-family: monospace;
   word-break: break-all;
-}
-
-#depub-disclaimer {
-  text-align: center;
 }

--- a/add-iscn-qr-code-to-epub/asset/iscn.xhtml
+++ b/add-iscn-qr-code-to-epub/asset/iscn.xhtml
@@ -8,17 +8,16 @@
 </head>
 
 <body>
-  <main>
-    <div id="iscn-page-book-info">
-      <div>
-        <b>ISCN: </b>
-        <span>
-          <a id="iscn-prefix" />
-          <img id="iscn-qr-code" width="250" height="250" src="iscn-qr-code.png" />
-        </span>
-      </div>
+  <div id="iscn-page-body">
+    <div id="iscn-page-book-info" />
+    <div id="iscn-qr-code">
+      <img src="iscn-qr-code.png" width="180px" height="180px" />
+      <br />
+      <a id="iscn-prefix" />
     </div>
-  </main>
-  <footer id="depub-disclaimer" />
+  </div>
+  <div id="iscn-page-footer">
+    <p id="depub-disclaimer" />
+  </div>
 </body>
 </html>

--- a/add-iscn-qr-code-to-epub/asset/iscn.xhtml
+++ b/add-iscn-qr-code-to-epub/asset/iscn.xhtml
@@ -9,15 +9,15 @@
 
 <body>
   <main>
-    <table id="iscn-page-book-info">
-      <tr>
-        <th>ISCN: </th>
-        <td>
+    <div id="iscn-page-book-info">
+      <div>
+        <b>ISCN: </b>
+        <span>
           <a id="iscn-prefix" />
           <img id="iscn-qr-code" width="250" height="250" src="iscn-qr-code.png" />
-        </td>
-      </tr>
-    </table>
+        </span>
+      </div>
+    </div>
   </main>
   <footer id="depub-disclaimer" />
 </body>

--- a/add-iscn-qr-code-to-epub/index.js
+++ b/add-iscn-qr-code-to-epub/index.js
@@ -139,11 +139,11 @@ function readInfoMap(opf$) {
  * @param {string} htmlToAppend
  */
 function addBookInfo(xhtml$, infoItemMap) {
-  const div = xhtml$('body table#iscn-page-book-info');
+  const div = xhtml$('#iscn-page-book-info');
   const itemsString = [...infoItemMap]
     .filter(([key, value]) => key && value)
     .map(([key, value]) => (
-      `    <tr><th>${key}: </th><td>${value}</td></tr>\n`
+      `    <div><b>${key}: </b><span>${value}</span></div>\n`
     ))
     .join('');
   div.prepend(itemsString);

--- a/add-iscn-qr-code-to-epub/index.js
+++ b/add-iscn-qr-code-to-epub/index.js
@@ -139,11 +139,11 @@ function readInfoMap(opf$) {
  * @param {string} htmlToAppend
  */
 function addBookInfo(xhtml$, infoItemMap) {
-  const div = xhtml$('#iscn-page-book-info');
+  const div = xhtml$('body #iscn-page-book-info');
   const itemsString = [...infoItemMap]
     .filter(([key, value]) => key && value)
     .map(([key, value]) => (
-      `    <div><b>${key}: </b><span>${value}</span></div>\n`
+      `<p>${key}: ${value}</p>\n`
     ))
     .join('');
   div.prepend(itemsString);


### PR DESCRIPTION
From @nwingt 's survey, epub.js doesn't support `<table>` well when displaying two pages with `column-width`.
Thus, we replace `<table>` with `<div>`.

Before:
<img width="1218" alt="截圖 2024-01-04 晚上10 59 43" src="https://github.com/likecoin/iscn-nft-tools/assets/33746295/230abaad-6f24-4088-ba6a-cc6ef181d47c">

After:
<img width="1218" alt="截圖 2024-01-04 晚上11 05 21" src="https://github.com/likecoin/iscn-nft-tools/assets/33746295/127610f8-103f-42fc-a108-5c6652e38fa3">


Any improvement is welcome.